### PR TITLE
Python 3 and QT5 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Temp Files
 *~
+.\__pycache__\*
 
 # emacs
 # dot hash files (write locks)

--- a/dos.py
+++ b/dos.py
@@ -90,7 +90,7 @@ class kmodule():
     """KiCad module."""
 
     def __init__(self, fname):
-        self.fout = open(fname, 'w')
+        self.fout = open(fname[0], 'w')
 
     def write_header(self, name='SIND', descr='spiral inductor', tags='SMD'):
         self.fout.write('(module %s (layer F.Cu)\n' % name)
@@ -325,7 +325,7 @@ class fh_file():
                     # take real and imag parts
                     pair = re.compile(r' *(\S+) +(\S+)j')
                     for ridx in range(nrows):
-                        lin = fzc.next()
+                        lin = fzc.readline()
                         # parse all complex data pairs
                         celms = pair.findall(lin)
                         matr = []
@@ -584,11 +584,11 @@ if __name__ == '__main__':
     din = 2 * r_in - tr_w + pitch / 2.0
     dout = 2 * r_in + (2 * N_turns - 0.5) * pitch + tr_w
     ind = calc_ind(N_turns, dout / 1e3, din / 1e3)
-    print 'din =', din
-    print 'dout =', dout
-    print 'ind =', ind
+    print('din =', din)
+    print('dout =', dout)
+    print('ind =', ind)
     k = calc_mut(N_turns, PCB_h)
-    print 'mutual ind =', k * ind, k
+    print('mutual ind =', k * ind, k)
 
     draw_arcs_spiral(N_turns, r_in, pitch, tr_w, N, -dir)
     sf.add_ports()
@@ -604,5 +604,5 @@ if __name__ == '__main__':
     sf.run()
 
     freqs, mats = sf.readZc()
-    print freqs
-    print mats
+    print(freqs)
+    print(mats)

--- a/spiki.py
+++ b/spiki.py
@@ -14,8 +14,8 @@ except ImportError:
 if (useNLopt):
     from numpy import *  # needed by nlopt
 
-from PyQt4 import QtGui, uic
-from PyQt4.QtCore import QThread
+from PyQt5 import QtGui, QtWidgets, uic
+from PyQt5.QtCore import QThread
 
 import dos
 
@@ -28,7 +28,7 @@ class kSpiralCalc(QtBaseClass, Ui_MainWindow):
         self.setupUi(self)
 
         # File
-        self.actionExit.triggered.connect(QtGui.qApp.quit)
+        self.actionExit.triggered.connect(QtWidgets.qApp.quit)
         self.actionSave_module.triggered.connect(self.writeModule)
 
         # add validators to LineEdits
@@ -117,7 +117,7 @@ class kSpiralCalc(QtBaseClass, Ui_MainWindow):
     def runSimulation(self):
         self.statusBar().showMessage("Simulating...")
         # update GUI to show changes status bar message
-        QtGui.QApplication.processEvents()
+        QtWidgets.QApplication.processEvents()
         self.simulate()
         self.statusBar().showMessage("Ready.")
 
@@ -207,7 +207,7 @@ class kSpiralCalc(QtBaseClass, Ui_MainWindow):
     def runOptimization(self):
         self.statusBar().showMessage("Optimizing...")
         # update GUI to show changes status bar message
-        QtGui.QApplication.processEvents()
+        QtWidgets.QApplication.processEvents()
 
         nTurns = float(self.nTurnsLineEdit.text())
         innerRadius = float(self.innerRadiusLineEdit.text())
@@ -223,7 +223,7 @@ class kSpiralCalc(QtBaseClass, Ui_MainWindow):
             if grad.size > 0:
                 grad = Null
             self.spacingLineEdit.setText(str(x[0]))
-            QtGui.QApplication.processEvents()  # update GUI
+            QtWidgets.QApplication.processEvents()  # update GUI
             ind = self.simulate()
             err = math.fabs(ind - targetInd)
             return err
@@ -235,20 +235,20 @@ class kSpiralCalc(QtBaseClass, Ui_MainWindow):
         opt.set_xtol_rel(1e-2)
         x = opt.optimize([spacing])
         minf = opt.last_optimum_value()
-        print "optimum at ", x[0]
-        print "minimum value = ", minf
-        print "result code = ", opt.last_optimize_result()
+        print("optimum at ", x[0])
+        print("minimum value = ", minf)
+        print("result code = ", opt.last_optimize_result())
 
         self.spacingLineEdit.setText(str(x[0]))
 
         self.statusBar().showMessage("Ready.")
 
-    def writeModule(self):
-        fname = QtGui.QFileDialog.getSaveFileName(self, 'Save Module', '.', 'Footprint (*.kicad_mod);;Any File (*)')
+    def writeModule(self):        
+        fname = QtWidgets.QFileDialog.getSaveFileName(self, 'Save Module', '.', 'Footprint (*.kicad_mod);;Any File (*)')        
         if (not fname):
             return
-        if (not fname.endsWith('.kicad_mod')):
-            fname = fname + '.kicad_mod'
+        if (not fname[0].endswith('.kicad_mod')):
+            fname[0] = fname[0] + '.kicad_mod'
 
         nTurns = float(self.nTurnsLineEdit.text())
         innerRadius = float(self.innerRadiusLineEdit.text())
@@ -325,9 +325,9 @@ class kSpiralCalc(QtBaseClass, Ui_MainWindow):
         din = 2 * innerRadius - traceWidth + pitch / 2.0
         dout = 2 * innerRadius + (2 * nTurns - 0.5) * pitch + traceWidth
         ind = dos.calc_ind(nTurns, dout / 1e3, din / 1e3)
-        # print 'din =', din
-        # print 'dout =', dout
-        # print 'ind =', ind
+        # print('din =', din)
+        # print('dout =', dout)
+        # print('ind =', ind)
 
         if (nLayers == 1):
             indtot = ind  # single-lyer inductor
@@ -339,7 +339,7 @@ class kSpiralCalc(QtBaseClass, Ui_MainWindow):
 
 
 def main():
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     form = kSpiralCalc()
     form.show()
     app.exec_()


### PR DESCRIPTION
Per issue #6:
I've modified the program to use Python3 style print() functions and the QT5 QTWidgets module where necessary. A small tweak was also necessary for the file save dialog - the filename tuple needed an index for some reason.

I made these changes since QT4 is a bit of a pain on Windows. QT5 is a simple pip install.